### PR TITLE
fix/namespaced keys implementation

### DIFF
--- a/lib/rack_session_redis/store.rb
+++ b/lib/rack_session_redis/store.rb
@@ -49,7 +49,7 @@ module RackSessionRedis
     end
 
     def keys
-      redis.keys.map do |key|
+      redis.keys("#{prefix}:*").map do |key|
         key.delete_prefix("#{prefix}:")
       end
     end

--- a/spec/rack_session_redis/store_spec.rb
+++ b/spec/rack_session_redis/store_spec.rb
@@ -143,6 +143,8 @@ RSpec.describe RackSessionRedis::Store do
       before do
         redis.set('rack_session:key1', Marshal.dump({ a: 1 }))
         redis.set('rack_session:key2', Marshal.dump({ a: 2 }))
+        redis.set('some_other_namespace:key3', Marshal.dump({ a: 3 }))
+        redis.set('key4', Marshal.dump({ a: 3 }))
       end
 
       it { is_expected.to eq(%w[key1 key2]) }


### PR DESCRIPTION
Currently, `keys` returns all keys regardless of namespace, then deletes the store prefix. 
I think it should probably search only for the namespaced keys.